### PR TITLE
Fix strings for Char and Palette animations in the "Built-in animations" page

### DIFF
--- a/docs/tmpanimator_builtinbasicanimations.html
+++ b/docs/tmpanimator_builtinbasicanimations.html
@@ -5,17 +5,17 @@
       <title>Built-in animations | TMPEffects </title>
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <meta name="title" content="Built-in animations | TMPEffects ">
-      
-      
+
+
       <link rel="icon" href="../favicon.ico">
       <link rel="stylesheet" href="../public/docfx.min.css">
       <link rel="stylesheet" href="../public/main.css">
       <meta name="docfx:navrel" content="../toc.html">
       <meta name="docfx:tocrel" content="toc.html">
-      
+
       <meta name="docfx:rel" content="../">
-      
-      
+
+
       <meta name="docfx:docurl" content="https://github.com/Luca3317/TMPEffects/blob/main/Documentation~/docs/tmpanimator_builtinbasicanimations.md/#L1">
       <meta name="loc:inThisArticle" content="In this article">
       <meta name="loc:searchResultsCount" content="{count} results for &quot;{query}&quot;">
@@ -206,7 +206,7 @@ input[type='checkbox'] {
             <li> WaveOffsetType: The way the offset for the wave is calculated.<br>
             <mark style="color: lightgray; background-color: #191a18">waveoffset</mark>, <mark style="color: lightgray; background-color: #191a18">woffset</mark>, <mark style="color: lightgray; background-color: #191a18">waveoff</mark>, <mark style="color: lightgray; background-color: #191a18">woff</mark></li>
             </ul>
-        
+
     </div>
   </div>
 </div>
@@ -238,7 +238,7 @@ input[type='checkbox'] {
             <li> FadeOutDirection: The direction used for fading out.<br>
             <mark style="color: lightgray; background-color: #191a18">fadeoutdirection</mark>, <mark style="color: lightgray; background-color: #191a18">fodirection</mark>, <mark style="color: lightgray; background-color: #191a18">fodir</mark>, <mark style="color: lightgray; background-color: #191a18">fod</mark></li>
         </ul>
-      
+
     </div>
   </div>
 </div>
@@ -266,7 +266,7 @@ input[type='checkbox'] {
             <li> MinAngleLimit: The minimum angle of the rotation.<br>
             <mark style="color: lightgray; background-color: #191a18">minangle</mark>, <mark style="color: lightgray; background-color: #191a18">mina</mark>, <mark style="color: lightgray; background-color: #191a18">min</mark></li>
         </ul>
-      
+
     </div>
   </div>
 </div>
@@ -289,7 +289,7 @@ input[type='checkbox'] {
             <li> Amplitude: The amplitude the text pushes to the left / right.<br>
             <mark style="color: lightgray; background-color: #191a18">amplitude</mark>, <mark style="color: lightgray; background-color: #191a18">amp</mark>
             </li></ul>
-        
+
     </div>
   </div>
 </div>
@@ -300,7 +300,7 @@ input[type='checkbox'] {
   Your browser does not support the video tag.
 </video>
   <input id="collapsiblechar" class="toggle" type="checkbox">
-  <label for="collapsiblechar" class="lbl-toggle">Fade Parameters</label>
+  <label for="collapsiblechar" class="lbl-toggle">Char Parameters</label>
   <div class="collapsible-content">
     <div class="content-inner">
       <p>
@@ -316,7 +316,7 @@ input[type='checkbox'] {
             <li> AutoCase: Whether to ensure capitalized characters are only changed to other capitalized characters, and vice versa.<br>
             <mark style="color: lightgray; background-color: #191a18">autocase</mark>, <mark style="color: lightgray; background-color: #191a18">case</mark>
         </li></ul>
-      
+
     </div>
   </div>
 </div>
@@ -349,7 +349,7 @@ input[type='checkbox'] {
             <li> MinWait: The maximum amount of time to wait after each shake.<br>
             <mark style="color: lightgray; background-color: #191a18">minwait</mark>, <mark style="color: lightgray; background-color: #191a18">minw</mark></li>
         </ul>
-      
+
     </div>
   </div>
 </div>
@@ -373,7 +373,7 @@ input[type='checkbox'] {
             <li> MinScale: The minimum scale to shrink to.<br>
             <mark style="color: lightgray; background-color: #191a18">minscale</mark>, <mark style="color: lightgray; background-color: #191a18">minscl</mark>, <mark style="color: lightgray; background-color: #191a18">min</mark></li>
             </ul>
-        
+
     </div>
   </div>
 </div>
@@ -384,7 +384,7 @@ input[type='checkbox'] {
   Your browser does not support the video tag.
 </video>
   <input id="collapsiblepalette" class="toggle" type="checkbox">
-  <label for="collapsiblepalette" class="lbl-toggle">Fade Parameters</label>
+  <label for="collapsiblepalette" class="lbl-toggle">Palette Parameters</label>
   <div class="collapsible-content">
     <div class="content-inner">
       <p>
@@ -395,7 +395,7 @@ input[type='checkbox'] {
             <li> Colors: The colors to cycle through.<br>
             <mark style="color: lightgray; background-color: #191a18">colors</mark>, <mark style="color: lightgray; background-color: #191a18">clrs</mark></li>
         </ul>
-      
+
     </div>
   </div>
 </div>
@@ -427,7 +427,7 @@ input[type='checkbox'] {
             <li> MinPercentage: The minimum percentage to unspread to, at 0 being completely hidden.<br>
             <mark style="color: lightgray; background-color: #191a18">minpercentage</mark>, <mark style="color: lightgray; background-color: #191a18">minp</mark>, <mark style="color: lightgray; background-color: #191a18">min</mark></li>
         </ul>
-      
+
     </div>
   </div>
 </div>
@@ -443,14 +443,14 @@ input[type='checkbox'] {
     <div class="content-inner">
       <p>
       <ul>
-          <li> Pivot: The pivot position of the rotation.<br>  
+          <li> Pivot: The pivot position of the rotation.<br>
           <mark style="color: lightgray; background-color: #191a18">pivot</mark>, <mark style="color: lightgray; background-color: #191a18">pv</mark>, <mark style="color: lightgray; background-color: #191a18">p</mark></li>
-          <li> RotationAxis: The axis to rotate around.<br>  
+          <li> RotationAxis: The axis to rotate around.<br>
           <mark style="color: lightgray; background-color: #191a18">rotationaxis</mark>, <mark style="color: lightgray; background-color: #191a18">axis</mark>, <mark style="color: lightgray; background-color: #191a18">a</mark></li>
-          <li> Speed: The speed of the rotation, in rotations per second.<br>  
+          <li> Speed: The speed of the rotation, in rotations per second.<br>
           <mark style="color: lightgray; background-color: #191a18">speed</mark>, <mark style="color: lightgray; background-color: #191a18">sp</mark>, <mark style="color: lightgray; background-color: #191a18">s</mark></li>
           </ul>
-      
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

The "Char" and "Palette" shown on the "Built-in animations" page were using "Fade" incorrectly. This change updates the strings to match appropriately.

## Changes

Updated the `lbl-toggle` text elements in the file `TMPEffects-Pages/docs/tmpanimator_builtinbasicanimations.html` to use the correct animation name for given parameters.

## Investigation

See my correction with a local fork of the TMPEffects page on the right:
<img width="1394" alt="Screenshot 2024-09-17 at 11 16 52 AM" src="https://github.com/user-attachments/assets/342b9c95-5e8b-4f5b-8c03-e7e7ceadff52">
